### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/DaveTCode/zmachine-golang/security/code-scanning/1](https://github.com/DaveTCode/zmachine-golang/security/code-scanning/1)

In general, the fix is to explicitly declare a minimal `permissions` block either at the workflow root (top-level, applying to all jobs) or at the individual job level. Because this workflow only checks out code and runs local Go build/test/coverage commands, it only needs read access to repository contents and no write scopes. The best minimal fix, preserving functionality, is to add `permissions: contents: read` at the top level below the `name:` or `on:` block so that all jobs (currently just `tests`) get read-only contents permissions by default.

Concretely, in `.github/workflows/build.yml`, add:

```yaml
permissions:
  contents: read
```

at the workflow root (for example between `name: Build` and `on:`). No other steps or actions need to be modified, and no additional methods or imports are required because this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
